### PR TITLE
Remove the create_map_and_set_sequence_num function.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -373,8 +373,9 @@ rmw_ret_t ClientData::send_request(
 
   // Send request
   zenoh::Session::GetOptions opts = zenoh::Session::GetOptions::create_default();
-  std::array<uint8_t, RMW_GID_STORAGE_SIZE> local_gid = entity_->copy_gid();
-  opts.attachment = rmw_zenoh_cpp::create_map_and_set_sequence_num(*sequence_id, local_gid);
+  int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
+  opts.attachment = rmw_zenoh_cpp::AttachmentData(
+    *sequence_id, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
   opts.target = Z_QUERY_TARGET_ALL_COMPLETE;
   // The default timeout for a z_get query is 10 seconds and if a response is not received within
   // this window, the queryable will return an invalid reply. However, it is common for actions,

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -251,10 +251,10 @@ rmw_ret_t PublisherData::publish(
   // session use different encoding formats. In our case, all key expressions
   // will be encoded with CDR so it does not really matter.
   zenoh::ZResult result;
-  int64_t source_timestamp = 0;
+  int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
   auto options = zenoh::Publisher::PutOptions::create_default();
-  options.attachment = create_map_and_set_sequence_num(
-    sequence_number_++, entity_->copy_gid(), &source_timestamp);
+  options.attachment = rmw_zenoh_cpp::AttachmentData(
+    sequence_number_++, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
 
   // TODO(ahcorde): shmbuf
   std::vector<uint8_t> raw_data(
@@ -299,10 +299,10 @@ rmw_ret_t PublisherData::publish_serialized_message(
   // session use different encoding formats. In our case, all key expressions
   // will be encoded with CDR so it does not really matter.
   zenoh::ZResult result;
-  int64_t source_timestamp = 0;
+  int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
   auto options = zenoh::Publisher::PutOptions::create_default();
-  options.attachment = create_map_and_set_sequence_num(
-    sequence_number_++, entity_->copy_gid(), &source_timestamp);
+  options.attachment = rmw_zenoh_cpp::AttachmentData(
+    sequence_number_++, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
 
   std::vector<uint8_t> raw_data(
     serialized_message->buffer,

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -444,11 +444,9 @@ rmw_ret_t ServiceData::send_response(
   zenoh::Query::ReplyOptions options = zenoh::Query::ReplyOptions::create_default();
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> writer_gid;
   memcpy(writer_gid.data(), request_id->writer_guid, RMW_GID_STORAGE_SIZE);
-  int64_t source_timestamp = 0;
-  options.attachment = create_map_and_set_sequence_num(
-    request_id->sequence_number,
-    writer_gid,
-    &source_timestamp);
+  int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
+  options.attachment = rmw_zenoh_cpp::AttachmentData(
+    request_id->sequence_number, source_timestamp, writer_gid).serialize_to_zbytes();
 
   std::vector<uint8_t> raw_bytes(
     reinterpret_cast<const uint8_t *>(response_bytes),

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
@@ -41,23 +41,6 @@ ZenohSession::~ZenohSession()
 }
 
 ///=============================================================================
-zenoh::Bytes create_map_and_set_sequence_num(
-  int64_t sequence_number,
-  std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid,
-  int64_t * source_timestamp)
-{
-  auto now = std::chrono::system_clock::now().time_since_epoch();
-  auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now);
-  int64_t timestamp = now_ns.count();
-  if (nullptr != source_timestamp) {
-    *source_timestamp = timestamp;
-  }
-
-  rmw_zenoh_cpp::AttachmentData data(sequence_number, timestamp, gid);
-  return data.serialize_to_zbytes();
-}
-
-///=============================================================================
 ZenohQuery::ZenohQuery(
   const zenoh::Query & query,
   std::chrono::nanoseconds::rep received_timestamp)
@@ -101,4 +84,11 @@ std::chrono::nanoseconds::rep ZenohReply::get_received_timestamp() const
 {
   return received_timestamp_;
 }
+
+int64_t get_system_time_in_ns()
+{
+  auto now = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+}
+
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
@@ -42,12 +42,6 @@ private:
 };
 
 ///=============================================================================
-zenoh::Bytes create_map_and_set_sequence_num(
-  int64_t sequence_number,
-  std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid,
-  int64_t * source_timestamp = nullptr);
-
-///=============================================================================
 // A class to store the replies to service requests.
 class ZenohReply final
 {
@@ -82,6 +76,8 @@ private:
   zenoh::Query query_;
   std::chrono::nanoseconds::rep received_timestamp_;
 };
+
+int64_t get_system_time_in_ns();
 }  // namespace rmw_zenoh_cpp
 
 #endif  // DETAIL__ZENOH_UTILS_HPP_


### PR DESCRIPTION
With the recent changes to get data out of it, and the change to zenoh-cpp, it can mostly be replaced with a couple of inline pieces of code.  However, we do add in a new function to help us explicitly get system clock time from std::chrono in nanoseconds.